### PR TITLE
Add server info tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@ The server provides the following tools:
         ```
 *   **list\_tactics:** This tool allows you to retrieve a list of all ATT&CK tactics.
     *   **Arguments:** None
+*   **server_info:** 返回服务与数据集的版本、维护者和Git信息。
+    *   **Arguments:** None
+    *   **Example:**
+        ```json
+        {}
+        ```
 
 ## Usage
 
@@ -71,7 +77,7 @@ To use this MCP server, you need to have an MCP client configured to connect to 
   ```
 - MCP 客户端配置服务类型为"http"，地址如 `http://127.0.0.1:8001/sse`。
 
-- **工具名称**：`query_technique`、`query_mitigations`、`query_detections`、`list_tactics`
+- **工具名称**：`query_technique`、`query_mitigations`、`query_detections`、`list_tactics`、`server_info`
 - **参数示例**：
   - 按ID查询技术：
     ```json
@@ -98,6 +104,10 @@ To use this MCP server, you need to have an MCP client configured to connect to 
     }
     ```
   - 查询战术列表：
+    ```json
+    {}
+    ```
+  - 查询服务与数据集信息：
     ```json
     {}
     ```
@@ -151,8 +161,9 @@ ATT&CK is a curated knowledge base and model for cyber adversary behavior, refle
 ## API 说明
 - /query_technique 通过ID或名称查询攻击技术详情（支持名称模糊搜索）
 - /query_mitigations 查询指定技术的缓解措施
-- /query_detections 查询指定技术的检测方法  
+- /query_detections 查询指定技术的检测方法
 - /list_tactics 获取所有ATT&CK战术分类
+- /server_info 返回服务版本、数据集版本和Git信息
 
 ---
 

--- a/main.py
+++ b/main.py
@@ -15,10 +15,13 @@ logger = logging.getLogger(__name__)
 
 # 初始化MCP服务器
 logger.info("正在初始化MCP服务器...")
+PROJECT_VERSION = "2.1"
+PROJECT_NAME = "ATT&CK_Query_Service"
+PROJECT_DESCRIPTION = "提供MITRE ATT&CK技术、战术及缓解措施的查询服务"
 mcp = FastMCP(
-    name="ATT&CK_Query_Service",
-    description="提供MITRE ATT&CK技术、战术及缓解措施的查询服务",
-    version="2.1"
+    name=PROJECT_NAME,
+    description=PROJECT_DESCRIPTION,
+    version=PROJECT_VERSION
 )
 
 attack_data = None
@@ -208,6 +211,63 @@ async def get_all_tactics():
     } for t in attack_data.get_tactics()]
     logger.info(f"返回 {len(tactics)} 个战术")
     return tactics
+
+
+@mcp.tool(
+    name="server_info",
+    description="返回项目工程、MCP库与ATT&CK数据集版本及维护信息，包括Git状态。",
+)
+async def server_info():
+    """获取服务和数据集的版本、维护者及Git信息。"""
+    import importlib.metadata
+    import subprocess
+
+    info = {
+        "intro": "Provides project, MCP library, ATT&CK dataset and git version details.",
+        "project": {
+            "name": PROJECT_NAME,
+            "version": PROJECT_VERSION,
+            "description": PROJECT_DESCRIPTION,
+            "maintainer": "Alex louis <ycliu912@126.com>",
+        },
+        "mcp": {
+            "library_version": importlib.metadata.version("mcp"),
+        },
+        "attack_dataset": {},
+        "git": {},
+    }
+
+    try:
+        data_path = os.path.join(os.path.dirname(__file__), "enterprise-attack.json")
+        with open(data_path, "r") as f:
+            data = json.load(f)
+        info["attack_dataset"] = {
+            "spec_version": data.get("spec_version"),
+            "attack_spec_version": data.get("objects", [{}])[0].get("x_mitre_attack_spec_version"),
+        }
+    except Exception as e:
+        info["attack_dataset"] = {"error": str(e)}
+
+    try:
+        git_version = subprocess.check_output(["git", "--version"]).decode().strip()
+        commit_id = subprocess.check_output(["git", "rev-parse", "HEAD"]).decode().strip()
+        commit_date = subprocess.check_output([
+            "git",
+            "log",
+            "-1",
+            "--pretty=%ad",
+        ]).decode().strip()
+        status_out = subprocess.check_output(["git", "status", "--short"]).decode().strip()
+        info["git"] = {
+            "version": git_version,
+            "commit_id": commit_id,
+            "commit_date": commit_date,
+            "status": "clean" if not status_out else status_out,
+        }
+    except Exception as e:
+        info["git"] = {"error": str(e)}
+
+    return info
 
 app = mcp.sse_app()
 


### PR DESCRIPTION
## Summary
- add `server_info` tool returning project, MCP, ATT&CK dataset and git metadata
- document `server_info` usage and configuration in README

## Testing
- `python -m py_compile main.py`
- `python - <<'PY'\nimport asyncio, json\nfrom main import server_info\nprint(json.dumps(asyncio.run(server_info()), indent=2, ensure_ascii=False))\nPY`

------
https://chatgpt.com/codex/tasks/task_e_68c0c3872cf883258dec419653042054