### PR TITLE
Improve CLI mode selection and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,20 +79,26 @@ To use this MCP server, you need to have an MCP client configured to connect to 
   ```bash
   python main.py
   ```
-- main.py 默认以 stdio (mcp.serve) 模式启动，适用于 Smithery、Cursor 等支持本地 MCP stdio 的客户端。
+- 程序会自动选择 stdio 模式（默认或 `ATTACK_MCP_MODE=stdio`），适用于 Smithery、Cursor 等支持本地 MCP stdio 的客户端。
 - MCP 客户端配置服务类型为"local/stdio"，无需指定端口。
 - 适用场景：Smithery 自动化、CI/CD、本地 AI Agent 集成。
 
 ### 2. HTTP/SSE 方式（远程/开发/调试）
 
-- 取消 main.py 末尾的 mcp.serve() 注释，启用 uvicorn 相关代码。
-- 启动服务：
+- 使用 CLI 参数切换模式：
   ```bash
-  python main.py
-  # 或
-  uvicorn main:app --host 0.0.0.0 --port 8001
+  python main.py --mode http --host 0.0.0.0 --port 8001 --log-level info
   ```
-- MCP 客户端配置服务类型为"http"，地址如 `http://127.0.0.1:8001/sse`。
+- 或通过环境变量控制：
+  ```bash
+  export ATTACK_MCP_MODE=http
+  export ATTACK_MCP_HOST=0.0.0.0   # 可选，默认 127.0.0.1 或 $HOST
+  export ATTACK_MCP_PORT=8001      # 可选，默认 8001 或 $PORT
+  export ATTACK_MCP_LOG_LEVEL=info # 可选，默认 info
+  python main.py
+  ```
+- 运行后服务以 HTTP/SSE 方式暴露，可在客户端配置服务类型为 "http"，地址如 `http://127.0.0.1:8001/sse`。
+- 远程部署（如 Smithery Cloud）通常会提供 `PORT` 或 `MCP_TRANSPORT` 环境变量，可直接 `python main.py` 即使用 HTTP。
 
 - **工具名称**：`query_technique`、`search_technique_full`、`query_mitigations`、`query_detections`、`list_tactics`、`server_info`
 - **参数示例**：

--- a/README.md
+++ b/README.md
@@ -162,11 +162,14 @@ ATT&CK is a curated knowledge base and model for cyber adversary behavior, refle
    pip install -r requirements.txt
    ```
 2. 确保 enterprise-attack.json 数据集在项目根目录。
-3. 启动服务：
+3. 启动服务（默认 stdio 模式，适用于本地客户端集成）：
    ```bash
    python main.py
    ```
-4. 服务默认监听 http://127.0.0.1:8001
+4. 如果需要以 HTTP/SSE 方式提供服务，请显式选择模式：
+   ```bash
+   python main.py --mode http --host 127.0.0.1 --port 8001
+   ```
 
 ### 方式二：生产环境推荐（Docker 或 Uvicorn）
 

--- a/main.py
+++ b/main.py
@@ -3,8 +3,10 @@ from mcp.server.fastmcp import FastMCP
 from mitreattack.stix20 import MitreAttackData
 from fastapi import HTTPException
 import uvicorn
+import argparse
+import sys
 import json
-from typing import Optional
+from typing import Optional, List
 import asyncio
 import logging
 import os
@@ -345,15 +347,102 @@ async def server_info():
 
 app = mcp.sse_app()
 
+
+def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="ATT&CK Query Service")
+    parser.add_argument(
+        "--version",
+        action="store_true",
+        help="显示版本信息并退出",
+    )
+    parser.add_argument(
+        "--mode",
+        choices=["http", "stdio"],
+        default=None,
+        help="选择运行模式: http 或 stdio。默认会根据环境变量或回退到 stdio。",
+    )
+    parser.add_argument(
+        "--host",
+        default=None,
+        help="HTTP 模式下监听的主机地址 (默认: 127.0.0.1 或 $HOST)",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=None,
+        help="HTTP 模式下监听的端口 (默认: 8001 或 $PORT)",
+    )
+    parser.add_argument(
+        "--log-level",
+        default=None,
+        help="HTTP 模式下的日志等级 (默认: info 或 $ATTACK_MCP_LOG_LEVEL)",
+    )
+    return parser.parse_args(argv)
+
+
+def normalize_mode(cli_mode: Optional[str]) -> str:
+    """Resolve the execution mode from CLI arguments and environment variables."""
+
+    env_mode = os.getenv("ATTACK_MCP_MODE") or os.getenv("MCP_TRANSPORT")
+    mode = (cli_mode or env_mode or "stdio").lower()
+
+    if mode not in {"stdio", "http"}:
+        raise ValueError(f"Unsupported mode '{mode}'. Use 'stdio' or 'http'.")
+
+    return mode
+
+
+def resolve_host(cli_host: Optional[str]) -> str:
+    return cli_host or os.getenv("ATTACK_MCP_HOST") or os.getenv("HOST") or "127.0.0.1"
+
+
+def resolve_port(cli_port: Optional[int]) -> int:
+    if cli_port is not None:
+        return cli_port
+
+    for env_var in ("ATTACK_MCP_PORT", "PORT"):
+        value = os.getenv(env_var)
+        if value:
+            try:
+                return int(value)
+            except ValueError:
+                raise ValueError(f"环境变量 {env_var} 的值 '{value}' 不是有效的端口号") from None
+
+    return 8001
+
+
+def resolve_log_level(cli_log_level: Optional[str]) -> str:
+    return (cli_log_level or os.getenv("ATTACK_MCP_LOG_LEVEL") or "info").lower()
+
+
+def main(argv: Optional[List[str]] = None) -> None:
+    args = parse_args(argv)
+
+    if args.version:
+        print(f"{PROJECT_NAME} v{PROJECT_VERSION}")
+        sys.exit(0)
+
+    try:
+        mode = normalize_mode(args.mode)
+        host = resolve_host(args.host)
+        port = resolve_port(args.port)
+        log_level = resolve_log_level(args.log_level)
+    except ValueError as exc:
+        logger.error(str(exc))
+        sys.exit(2)
+
+    logger.info("启动模式: %s", mode)
+
+    if mode == "stdio":
+        mcp.run()
+    else:
+        uvicorn.run(
+            app=app,
+            host=host,
+            port=port,
+            log_level=log_level,
+        )
+
+
 if __name__ == "__main__":
-    # 只需切换下方注释即可选择 stdio 或 http 模式
-    # --- MCP stdio 模式（Smithery/本地集成推荐）---
-    mcp.run()
-    # --- HTTP/SSE 模式（开发/调试/远程部署推荐）---
-    # import uvicorn
-    # uvicorn.run(
-    #     "main:app",
-    #     host="127.0.0.1",
-    #     port=8001,
-    #     log_level="info"
-    # )
+    main()


### PR DESCRIPTION
## Summary
- allow CLI options to fall back to environment variables and validate mode, host, port, and log level before launching
- provide a unified `main` entry point that logs the selected transport and keeps stdio as the default
- document the new CLI and environment-variable workflow for selecting stdio or HTTP modes in the README

## Testing
- python -m compileall main.py

------
https://chatgpt.com/codex/tasks/task_e_68db3d7e69648325a722a93734066679