### PR TITLE
Handle additional MCP transport aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ To use this MCP server, you need to have an MCP client configured to connect to 
   python main.py
   ```
 - 运行后服务以 HTTP/SSE 方式暴露，可在客户端配置服务类型为 "http"，地址如 `http://127.0.0.1:8001/sse`。
-- 远程部署（如 Smithery Cloud）通常会提供 `PORT` 或 `MCP_TRANSPORT` 环境变量，可直接 `python main.py` 即使用 HTTP。
+- 远程部署（如 Smithery Cloud）通常会提供 `PORT` 或 `MCP_TRANSPORT` 环境变量，可直接 `python main.py` 即使用 HTTP。对于值为 `streaming`、`streamable`、`streamable-http`、`streamable HTTP transport` 或 `stdioNotSupported` 等新枚举的运行环境，程序会自动回退到 HTTP/SSE 模式，无需额外配置。
 
 - **工具名称**：`query_technique`、`search_technique_full`、`query_mitigations`、`query_detections`、`list_tactics`、`server_info`
 - **参数示例**：

--- a/main.py
+++ b/main.py
@@ -380,15 +380,70 @@ def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
     return parser.parse_args(argv)
 
 def normalize_mode(cli_mode: Optional[str]) -> str:
-    """Resolve the execution mode from CLI arguments and environment variables."""
+    """Resolve the execution mode from CLI arguments and environment variables.
+
+    Some remote runtimes (for example Smithery) require an HTTP/SSE transport and
+    communicate this requirement through the ``MCP_TRANSPORT`` environment
+    variable.  Historically only ``"stdio"`` and ``"http"`` were supported, but
+    new values such as ``"streaming"`` or ``"streamable"`` are now emitted.  To
+    avoid hard failures we normalise a wider range of aliases to one of the two
+    execution modes supported by the server.
+    """
 
     env_mode = os.getenv("ATTACK_MCP_MODE") or os.getenv("MCP_TRANSPORT")
-    mode = (cli_mode or env_mode or "stdio").lower()
+    raw_mode = (cli_mode or env_mode or "").strip().lower()
 
-    if mode not in {"stdio", "http"}:
-        raise ValueError(f"Unsupported mode '{mode}'. Use 'stdio' or 'http'.")
+    def _canonicalise(value: str) -> str:
+        """Return a normalised key containing only lowercase alpha-numerics."""
 
-    return mode
+        return "".join(ch for ch in value if ch.isalnum())
+
+    canonical_mode = _canonicalise(raw_mode)
+
+    mode_aliases = {
+        "": None,
+        "stdio": "stdio",
+        "http": "http",
+        "https": "http",
+        "sse": "http",
+        "stream": "http",
+        "streaming": "http",
+        "streamable": "http",
+        "streamablehttp": "http",
+        "streamablehttptransport": "http",
+        "httpstreaming": "http",
+        "stdionotsupported": "http",
+    }
+
+    if raw_mode in mode_aliases:
+        resolved_mode = mode_aliases[raw_mode]
+    else:
+        resolved_mode = mode_aliases.get(canonical_mode)
+
+    if not resolved_mode:
+        # If the canonical form still contains hints of http/streaming we fall
+        # back to the HTTP server.  This allows values such as "streamable-http"
+        # or "streamable http" to work without having to list every variant.
+        if canonical_mode:
+            if "http" in canonical_mode or "sse" in canonical_mode or "stream" in canonical_mode:
+                resolved_mode = "http"
+            elif "stdio" in canonical_mode:
+                resolved_mode = "stdio"
+
+    if raw_mode and resolved_mode is None:
+        raise ValueError(
+            f"Unsupported mode '{raw_mode}'. Use 'stdio' or 'http'."
+        )
+
+    if resolved_mode:
+        return resolved_mode
+
+    # No explicit mode was provided. Default to HTTP when a port hint is
+    # available (common on remote deployments), otherwise fall back to stdio.
+    if os.getenv("ATTACK_MCP_PORT") or os.getenv("PORT"):
+        return "http"
+
+    return "stdio"
 
 
 def resolve_host(cli_host: Optional[str]) -> str:


### PR DESCRIPTION
## Summary
- broaden transport normalisation to accept additional streamable HTTP aliases and heuristically fall back to HTTP
- document the expanded automatic HTTP/SSE fallback behaviour in the README

## Testing
- python -m compileall main.py

------
https://chatgpt.com/codex/tasks/task_e_68db436fe188832583a7540c709083ac