### PR TITLE
Add streamable HTTP deployment configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,16 @@ FROM python:3.11-slim
 
 WORKDIR /app
 
+ENV PYTHONUNBUFFERED=1
+
+COPY requirements.txt ./
+RUN pip install --upgrade pip \
+    && pip install --no-cache-dir -r requirements.txt
+
 COPY . .
 
-RUN pip install --upgrade pip && pip install -r requirements.txt
+ENV TRANSPORT=http
 
-EXPOSE 8001
+EXPOSE 8081
 
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8001"] 
+CMD ["python", "main.py"]

--- a/README.md
+++ b/README.md
@@ -83,22 +83,23 @@ To use this MCP server, you need to have an MCP client configured to connect to 
 - MCP 客户端配置服务类型为"local/stdio"，无需指定端口。
 - 适用场景：Smithery 自动化、CI/CD、本地 AI Agent 集成。
 
-### 2. HTTP/SSE 方式（远程/开发/调试）
+### 2. HTTP/Streamable 方式（远程/开发/调试）
 
 - 使用 CLI 参数切换模式：
   ```bash
-  python main.py --mode http --host 0.0.0.0 --port 8001 --log-level info
+  python main.py --mode http --host 0.0.0.0 --port 8081 --log-level info
   ```
 - 或通过环境变量控制：
   ```bash
   export ATTACK_MCP_MODE=http
-  export ATTACK_MCP_HOST=0.0.0.0   # 可选，默认 127.0.0.1 或 $HOST
-  export ATTACK_MCP_PORT=8001      # 可选，默认 8001 或 $PORT
+  export ATTACK_MCP_HOST=0.0.0.0   # 可选，默认 0.0.0.0 或 $HOST
+  export ATTACK_MCP_PORT=8081      # 可选，默认 8081 或 $PORT
   export ATTACK_MCP_LOG_LEVEL=info # 可选，默认 info
   python main.py
   ```
-- 运行后服务以 HTTP/SSE 方式暴露，可在客户端配置服务类型为 "http"，地址如 `http://127.0.0.1:8001/sse`。
-- 远程部署（如 Smithery Cloud）通常会提供 `PORT` 或 `MCP_TRANSPORT` 环境变量，可直接 `python main.py` 即使用 HTTP。
+- 运行后服务以 streamable HTTP 方式暴露，可在客户端配置服务类型为 "http"，地址如 `http://127.0.0.1:8081/mcp`。
+- 远程部署（如 Smithery Cloud）通常会提供 `PORT` 或 `MCP_TRANSPORT` 环境变量，可直接运行 `python main.py` 即使用 HTTP。对于值为 `streaming`、`streamable`、`streamable-http`、`streamable HTTP transport` 或 `stdioNotSupported` 等新枚举的运行环境，程序会自动回退到 HTTP 模式，无需额外配置。
+- Smithery 等容器平台会通过 `PORT`（默认为 8081）告知监听端口；程序会自动读取该值并监听在 `0.0.0.0:$PORT`。
 
 - **工具名称**：`query_technique`、`search_technique_full`、`query_mitigations`、`query_detections`、`list_tactics`、`server_info`
 - **参数示例**：
@@ -166,12 +167,12 @@ ATT&CK is a curated knowledge base and model for cyber adversary behavior, refle
    ```bash
    python main.py
    ```
-4. 如果需要以 HTTP/SSE 方式提供服务，请显式选择模式：
+4. 如果需要以 HTTP 方式提供服务，请显式选择模式：
    ```bash
-   python main.py --mode http --host 127.0.0.1 --port 8001
+   python main.py --mode http --host 127.0.0.1 --port 8081
    ```
 
-### 方式二：生产环境推荐（Docker 或 Uvicorn）
+### 方式二：生产环境推荐（Docker 部署）
 
 #### Docker
 1. 构建镜像：
@@ -180,12 +181,7 @@ ATT&CK is a curated knowledge base and model for cyber adversary behavior, refle
    ```
 2. 运行容器：
    ```bash
-   docker run -p 8001:8001 attack-mcp-server
-   ```
-
-#### Uvicorn 命令行
-   ```bash
-   uvicorn main:app --host 0.0.0.0 --port 8001
+   docker run -p 8081:8081 attack-mcp-server
    ```
 
 ---

--- a/main.py
+++ b/main.py
@@ -2,6 +2,7 @@
 from mcp.server.fastmcp import FastMCP
 from mitreattack.stix20 import MitreAttackData
 from fastapi import HTTPException
+from starlette.middleware.cors import CORSMiddleware
 import uvicorn
 import argparse
 import sys
@@ -345,9 +346,6 @@ async def server_info():
 
     return info
 
-app = mcp.sse_app()
-
-
 def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="ATT&CK Query Service")
     parser.add_argument(
@@ -364,13 +362,13 @@ def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
     parser.add_argument(
         "--host",
         default=None,
-        help="HTTP 模式下监听的主机地址 (默认: 127.0.0.1 或 $HOST)",
+        help="HTTP 模式下监听的主机地址 (默认: 0.0.0.0 或 $HOST)",
     )
     parser.add_argument(
         "--port",
         type=int,
-        default=8001,
-        help="HTTP 模式下监听的端口 (默认: 8001)",
+        default=8081,
+        help="HTTP 模式下监听的端口 (默认: 8081)",
     )
     parser.add_argument(
         "--log-level",
@@ -380,26 +378,95 @@ def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
     return parser.parse_args(argv)
 
 def normalize_mode(cli_mode: Optional[str]) -> str:
-    """Resolve the execution mode from CLI arguments and environment variables."""
+    """Resolve the execution mode from CLI arguments and environment variables.
 
-    env_mode = os.getenv("ATTACK_MCP_MODE") or os.getenv("MCP_TRANSPORT")
-    mode = (cli_mode or env_mode or "stdio").lower()
+    Some remote runtimes (for example Smithery) require an HTTP/SSE transport and
+    communicate this requirement through the ``MCP_TRANSPORT`` environment
+    variable.  Historically only ``"stdio"`` and ``"http"`` were supported, but
+    new values such as ``"streaming"`` or ``"streamable"`` are now emitted.  To
+    avoid hard failures we normalise a wider range of aliases to one of the two
+    execution modes supported by the server.
+    """
 
-    if mode not in {"stdio", "http"}:
-        raise ValueError(f"Unsupported mode '{mode}'. Use 'stdio' or 'http'.")
+    env_mode = (
+        os.getenv("ATTACK_MCP_MODE")
+        or os.getenv("TRANSPORT")
+        or os.getenv("MCP_TRANSPORT")
+    )
+    raw_mode = (cli_mode or env_mode or "").strip().lower()
 
-    return mode
+    def _canonicalise(value: str) -> str:
+        """Return a normalised key containing only lowercase alpha-numerics."""
+
+        return "".join(ch for ch in value if ch.isalnum())
+
+    canonical_mode = _canonicalise(raw_mode)
+
+    mode_aliases = {
+        "": None,
+        "stdio": "stdio",
+        "http": "http",
+        "https": "http",
+        "sse": "http",
+        "stream": "http",
+        "streaming": "http",
+        "streamable": "http",
+        "streamablehttp": "http",
+        "streamablehttptransport": "http",
+        "streamablehttps": "http",
+        "httpstreaming": "http",
+        "stdionotsupported": "http",
+    }
+
+    if raw_mode in mode_aliases:
+        resolved_mode = mode_aliases[raw_mode]
+    else:
+        resolved_mode = mode_aliases.get(canonical_mode)
+
+    if not resolved_mode:
+        # If the canonical form still contains hints of http/streaming we fall
+        # back to the HTTP server.  This allows values such as "streamable-http"
+        # or "streamable http" to work without having to list every variant.
+        if canonical_mode:
+            if "http" in canonical_mode or "sse" in canonical_mode or "stream" in canonical_mode:
+                resolved_mode = "http"
+            elif "stdio" in canonical_mode:
+                resolved_mode = "stdio"
+
+    if raw_mode and resolved_mode is None:
+        raise ValueError(
+            f"Unsupported mode '{raw_mode}'. Use 'stdio' or 'http'."
+        )
+
+    if resolved_mode:
+        return resolved_mode
+
+    # No explicit mode was provided. Default to HTTP when a port hint is
+    # available (common on remote deployments), otherwise fall back to stdio.
+    if (
+        os.getenv("ATTACK_MCP_PORT")
+        or os.getenv("PORT")
+        or os.getenv("SMITHERY_PORT")
+    ):
+        return "http"
+
+    return "stdio"
 
 
 def resolve_host(cli_host: Optional[str]) -> str:
-    return cli_host or os.getenv("ATTACK_MCP_HOST") or os.getenv("HOST") or "127.0.0.1"
+    return (
+        cli_host
+        or os.getenv("ATTACK_MCP_HOST")
+        or os.getenv("HOST")
+        or "0.0.0.0"
+    )
 
 
 def resolve_port(cli_port: Optional[int]) -> int:
     if cli_port is not None:
         return cli_port
 
-    for env_var in ("ATTACK_MCP_PORT", "PORT"):
+    for env_var in ("ATTACK_MCP_PORT", "PORT", "SMITHERY_PORT"):
         value = os.getenv(env_var)
         if value:
             try:
@@ -407,7 +474,7 @@ def resolve_port(cli_port: Optional[int]) -> int:
             except ValueError:
                 raise ValueError(f"环境变量 {env_var} 的值 '{value}' 不是有效的端口号") from None
 
-    return 8001
+    return 8081
 
 
 def resolve_log_level(cli_log_level: Optional[str]) -> str:
@@ -434,13 +501,31 @@ def main(argv: Optional[List[str]] = None) -> None:
 
     if mode == "stdio":
         mcp.run()
-    else:
-        uvicorn.run(
-            app=app,
-            host=host,
-            port=port,
-            log_level=log_level,
-        )
+        return
+
+    app = create_http_app()
+    uvicorn.run(
+        app=app,
+        host=host,
+        port=port,
+        log_level=log_level,
+    )
+
+
+def create_http_app():
+    """Create the FastMCP HTTP application with permissive CORS headers."""
+
+    app = mcp.streamable_http_app()
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=["*"],
+        allow_credentials=True,
+        allow_methods=["GET", "POST", "OPTIONS"],
+        allow_headers=["*"],
+        expose_headers=["mcp-session-id", "mcp-protocol-version"],
+        max_age=86400,
+    )
+    return app
 
 
 if __name__ == "__main__":

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,15 +1,10 @@
-# Smithery.ai configuration
+# Smithery.ai configuration for container-based deployments
+runtime: container
+build:
+  dockerfile: Dockerfile
+  dockerBuildPath: .
 startCommand:
-  type: stdio
-  configSchema: {}
-  commandFunction: |-
-    (config) => ({
-      command: "python",
-      args: [
-        "main.py"
-      ],
-      env: {}
-    })
+  type: http
 tools:
   - query_technique
   - search_technique_full


### PR DESCRIPTION
## Summary
- add a dedicated streamable HTTP FastMCP app with CORS and improved transport/port resolution
- update Docker and smithery configuration to run the server in HTTP mode inside container deployments
- refresh the README with HTTP usage instructions, default port changes, and container deployment notes

## Testing
- python -m compileall main.py

------
https://chatgpt.com/codex/tasks/task_e_68db436fe188832583a7540c709083ac