### PR TITLE
Fix Smithery tool discovery

### DIFF
--- a/main.py
+++ b/main.py
@@ -562,7 +562,8 @@ def create_http_app():
                             "experimental": {},
                             "prompts": {"listChanged": False},
                             "resources": {"subscribe": False, "listChanged": False},
-                            "tools": {"listChanged": False}
+                            # 标记工具列表已更新，提示客户端主动获取可用工具。
+                            "tools": {"listChanged": True}
                         },
                         "serverInfo": {
                             "name": PROJECT_NAME,


### PR DESCRIPTION
## Summary
- mark the Smithery initialize response so the tools list is treated as updated
- add inline documentation explaining why the flag is enabled

## Testing
- python - <<'PY'
import httpx

url = 'http://127.0.0.1:8081/mcp'
headers = {'Content-Type': 'application/json'}
init_req = {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "initialize",
    "params": {
        "clientInfo": {"name": "test", "version": "0"},
        "protocolVersion": "2024-11-05"
    }
}
with httpx.Client() as client:
    resp = client.post(url, headers=headers, json=init_req)
    print(resp.json())
PY

------
https://chatgpt.com/codex/tasks/task_e_68dc1588e71c832598cdfd28dd894f46