### PR TITLE
Handle Smithery initialization notifications

### DIFF
--- a/main.py
+++ b/main.py
@@ -541,6 +541,7 @@ def create_http_app():
         """处理Smithery的JSON-RPC请求，绕过SSE会话要求"""
         from starlette.responses import JSONResponse
         import json
+        from starlette.responses import Response
         
         try:
             body = await request.body()
@@ -562,7 +563,8 @@ def create_http_app():
                             "experimental": {},
                             "prompts": {"listChanged": False},
                             "resources": {"subscribe": False, "listChanged": False},
-                            "tools": {"listChanged": False}
+                            # 标记工具列表已更新，提示客户端主动获取可用工具。
+                            "tools": {"listChanged": True}
                         },
                         "serverInfo": {
                             "name": PROJECT_NAME,
@@ -705,9 +707,9 @@ def create_http_app():
                     "result": {"prompts": []}
                 }
                 return JSONResponse(response)
-            elif data.get("method") == "initialized":
-                response = {"jsonrpc": "2.0", "result": None} # Return null for initialized notification
-                return JSONResponse(response, status_code=204)
+            elif data.get("method") in {"initialized", "notifications/initialized"}:
+                """Acknowledge initialization notifications without returning a body."""
+                return Response(status_code=204)
             else:
                 # 对于其他方法，返回错误
                 response = {
@@ -952,7 +954,7 @@ class MessageEndpointAliasMiddleware:
                             "experimental": {},
                             "prompts": {"listChanged": False},
                             "resources": {"subscribe": False, "listChanged": False},
-                            "tools": {"listChanged": False}
+                            "tools": {"listChanged": True}
                         },
                         "serverInfo": {
                             "name": PROJECT_NAME,


### PR DESCRIPTION
## Summary
- acknowledge Smithery initialization notifications without returning JSON-RPC errors
- ensure initialize responses consistently report updated tool lists for Smithery clients

## Testing
- python - <<'PY'
import httpx, json
url='http://127.0.0.1:8081/mcp'
headers={'Content-Type':'application/json'}
init_req={
    "jsonrpc":"2.0",
    "id":1,
    "method":"initialize",
    "params":{
        "protocolVersion":"2024-11-05",
        "clientInfo":{"name":"test","version":"0"}
    }
}
with httpx.Client() as client:
    resp=client.post(url, headers=headers, json=init_req)
    print('initialize status', resp.status_code)
    print(json.dumps(resp.json(), indent=2, ensure_ascii=False))
    notif_req={"jsonrpc":"2.0","method":"notifications/initialized"}
    resp_notif=client.post(url, headers=headers, json=notif_req)
    print('notif status', resp_notif.status_code)
    print('notif body', resp_notif.text)
    tools_req={"jsonrpc":"2.0","id":2,"method":"tools/list"}
    resp2=client.post(url, headers=headers, json=tools_req)
    print('tools status', resp2.status_code)
    print(json.dumps(resp2.json(), indent=2, ensure_ascii=False))
PY

------
https://chatgpt.com/codex/tasks/task_e_68dc1588e71c832598cdfd28dd894f46